### PR TITLE
Bevy 0.12 update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ categories = ["game-development"]
 exclude = ["assets/*"]
 
 [dependencies]
-bevy = { version = "0.11.2", default-features = false }
+bevy = { version = "0.12.1", default-features = false }
 
 [dev-dependencies.bevy]
-version = "0.11.2"
+version = "0.12.1"
 default-features = false
 features = [
     "bevy_core_pipeline",

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,11 +1,5 @@
-use bevy::{
-    input::touch,
-    prelude::{
-        error, info, App, Camera, Commands, Component, Entity, OrthographicProjection, Plugin,
-        PostStartup, Query, Res, ResMut, Resource, Touches, Transform, Update, Vec2, Vec3, With,
-    },
-    time::Time,
-};
+use bevy::input::touch;
+use bevy::prelude::*;
 
 /// A plugin that will update camera movement based on `Touch` gestures that Bevy provides
 #[derive(Default)]


### PR DESCRIPTION
Updated for bevy 0.12

The only change I did was to include the prelude to get rid of this deprecation warning:

```
warning: use of deprecated function `bevy::prelude::error`: use `.map(bevy_utils::error)` instead
 --> src/plugin.rs:4:9
  |
4 |         error, info, App, Camera, Commands, Component, Entity, OrthographicProjection, Plugin,
  |         ^^^^^
  |
  = note: `#[warn(deprecated)]` on by default

warning: use of deprecated function `bevy::prelude::info`: use `.map(bevy_utils::info)` instead
 --> src/plugin.rs:4:16
  |
4 |         error, info, App, Camera, Commands, Component, Entity, OrthographicProjection, Plugin,
  |                ^^^^

warning: `bevy_touch_camera` (lib) generated 2 warnings
```